### PR TITLE
fix(test): TradeLegControllerTest - fix NegativeNotional() validation

### DIFF
--- a/backend/src/test/java/com/technicalchallenge/controller/TradeLegControllerTest.java
+++ b/backend/src/test/java/com/technicalchallenge/controller/TradeLegControllerTest.java
@@ -163,7 +163,7 @@ public class TradeLegControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(tradeLegDTO)))
                 .andExpect(status().isBadRequest())
-                .andExpect(content().string("Notional must be positive"));
+                .andExpect(jsonPath("$.notional", is("Notional must be positive")));
 
         verify(tradeLegService, never()).saveTradeLeg(any(TradeLeg.class), any(TradeLegDTO.class));
     }


### PR DESCRIPTION
- Problem: testCreateTradeLegValidationFailure_NegativeNotional() was returning null response body and assertion failed. Response content expected:<Notional must be positive> but was:<>
- Root Cause: incorrect jsonPath matcher
- Solution: Updated test with .andExpect(jsonPath("$.notional", is("Notional must be positive")))
- Impact: Enables proper verification of expected behaviour when notional is negative which is 400 response with the expected error message