### PR TITLE
fix: clear auth state on sign out to prevent 403 errors

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -49,6 +49,7 @@ const Navbar = () => {
                         aria-label="signout"
                         onClick={() => {
                             localStorage.setItem('authenticated', 'false');
+                            sessionStorage.removeItem('authHeader');
                             navigate('/signin');
                         }}
                     >


### PR DESCRIPTION
This update removes authHeader from sessionStorage when the user signs out